### PR TITLE
Update slack.py to post as authenticated user.

### DIFF
--- a/alexa_slack/slack.py
+++ b/alexa_slack/slack.py
@@ -9,7 +9,7 @@ def post_to_slack(channel, text, token):
         'token': token,
         'channel': channel,
         'text': text,
-        'as_user': False,
+        'as_user': True,
     })
     if res.json()['ok']:
         return PlainTextSpeech("Okay. Your message has been posted.")


### PR DESCRIPTION
post as authenticated user rather than bot: 
see https://api.slack.com/methods/chat.postMessage#authorship

My thoughts are to perhaps make this configurable, using phrases such as "post as bot" or "post as myself/user", but I'd like a second opinion from the original author of course :)